### PR TITLE
SAR-389: Added routing for preferences and updated summary

### DIFF
--- a/app/connectors/models/preferences/PaperlessState.scala
+++ b/app/connectors/models/preferences/PaperlessState.scala
@@ -27,7 +27,7 @@ object PaperlessState {
 
   import utils.Implicits.{EitherUtilLeft, EitherUtilRight}
 
-  val Paperless = "paperless"
+  val Paperless = "optedIn"
 
   val parseResponse: HttpResponse => Boolean = (response: HttpResponse) => (response.json \ Paperless).get.as[Boolean]
 

--- a/app/controllers/EligibleController.scala
+++ b/app/controllers/EligibleController.scala
@@ -43,7 +43,7 @@ class EligibleController @Inject()(val baseConfig: BaseControllerConfig,
 
   val submitEligible: Action[AnyContent] = Authorised.async { implicit user =>
     implicit request =>
-      Future.successful(Redirect(controllers.routes.ContactEmailController.showContactEmail()))
+      Future.successful(Redirect(controllers.preferences.routes.PreferencesController.checkPreferences()))
   }
 
   lazy val backUrl: String = controllers.property.routes.PropertyIncomeController.showPropertyIncome().url

--- a/app/controllers/NotEligibleController.scala
+++ b/app/controllers/NotEligibleController.scala
@@ -73,7 +73,7 @@ class NotEligibleController @Inject()(val baseConfig: BaseControllerConfig,
           case IncomeSourceForm.option_business | IncomeSourceForm.option_both =>
             Redirect(controllers.business.routes.BusinessAccountingPeriodController.showAccountingPeriod())
           case IncomeSourceForm.option_property =>
-            Redirect(controllers.routes.ContactEmailController.showContactEmail())
+            Redirect(controllers.preferences.routes.PreferencesController.checkPreferences())
         }
       case _ => throw new InternalServerException("NotEligibleController: fetchIncomeSource failed")
     }

--- a/app/controllers/TermsController.scala
+++ b/app/controllers/TermsController.scala
@@ -59,6 +59,6 @@ class TermsController @Inject()(val baseConfig: BaseControllerConfig,
       )
   }
 
-  lazy val backUrl: String = controllers.routes.ContactEmailController.showContactEmail().url
+  lazy val backUrl: String = controllers.preferences.routes.PreferencesController.checkPreferences().url
 
 }

--- a/app/controllers/TermsController.scala
+++ b/app/controllers/TermsController.scala
@@ -37,8 +37,7 @@ class TermsController @Inject()(val baseConfig: BaseControllerConfig,
   def view(termsForm: Form[TermModel])(implicit request: Request[_]): Html =
     views.html.terms(
       termsForm = termsForm,
-      postAction = controllers.routes.TermsController.submitTerms(),
-      backUrl = backUrl
+      postAction = controllers.routes.TermsController.submitTerms()
     )
 
   val showTerms: Action[AnyContent] = Authorised.async { implicit user =>
@@ -58,7 +57,4 @@ class TermsController @Inject()(val baseConfig: BaseControllerConfig,
         }
       )
   }
-
-  lazy val backUrl: String = controllers.preferences.routes.PreferencesController.checkPreferences().url
-
 }

--- a/app/controllers/business/BusinessIncomeTypeController.scala
+++ b/app/controllers/business/BusinessIncomeTypeController.scala
@@ -59,7 +59,7 @@ class BusinessIncomeTypeController @Inject()(val baseConfig: BaseControllerConfi
             if (isEditMode)
               Redirect(controllers.routes.SummaryController.showSummary())
             else
-              Redirect(controllers.routes.ContactEmailController.showContactEmail()))
+              Redirect(controllers.preferences.routes.PreferencesController.checkPreferences()))
         }
       )
   }

--- a/app/controllers/preferences/PreferencesController.scala
+++ b/app/controllers/preferences/PreferencesController.scala
@@ -39,14 +39,14 @@ class PreferencesController @Inject()(val baseConfig: BaseControllerConfig,
   def view(backToPreferencesForm: Form[BackToPreferencesModel])(implicit request: Request[AnyContent]): Html = {
     views.html.preferences.continue_registration(
       backToPreferencesForm,
-      postAction = controllers.preferences.routes.PreferencesController.submitGoBackToPreferences
+      postAction = controllers.preferences.routes.PreferencesController.submitGoBackToPreferences()
     )
   }
 
   def checkPreferences: Action[AnyContent] = Authorised.async { implicit user =>
     implicit request =>
       preferencesService.checkPaperless.map {
-        case Activated => Ok(Activated.toString)
+        case Activated => Redirect(controllers.routes.TermsController.showTerms())
         case _ => gotoPreferences
       }
   }
@@ -54,7 +54,7 @@ class PreferencesController @Inject()(val baseConfig: BaseControllerConfig,
   def callback: Action[AnyContent] = Authorised.async { implicit user =>
     implicit request =>
       preferencesService.checkPaperless.map {
-        case Activated => Ok(Activated.toString)
+        case Activated => Redirect(controllers.routes.TermsController.showTerms())
         case _ => Redirect(controllers.preferences.routes.PreferencesController.showGoBackToPreferences())
       }
   }

--- a/app/views/summary_page.scala.html
+++ b/app/views/summary_page.scala.html
@@ -53,13 +53,13 @@
     summaryRow(rowName, rowQuestion, rowAnswer, rowUrl)
 }
 
-@contactEmail(email: EmailModel) = @{
+<!--@contactEmail(email: EmailModel) = @{
     val rowName = ContactEmailId
     val rowQuestion = Messages("summary.contact_email")
     val rowAnswer = email.emailAddress
     val rowUrl = controllers.routes.ContactEmailController.showContactEmail(editMode = true).url
     summaryRow(rowName, rowQuestion, rowAnswer, rowUrl)
-}
+}-->
 
 @terms(terms: TermModel) = @{
     if(terms.hasAcceptedTerms) {

--- a/app/views/terms.scala.html
+++ b/app/views/terms.scala.html
@@ -5,12 +5,11 @@
 @import views.html.helpers._
 @import config.AppConfig
 
-@(termsForm: Form[TermModel], postAction: Call, backUrl: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(termsForm: Form[TermModel], postAction: Call)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @termsHref = @{"https://www.gov.uk/help/terms-conditions"}
 
 @views.html.templates.main_template(title = Messages("terms.title"), bodyClasses = None) {
-    @back_link(backUrl)
 
     @summaryErrorHelper(termsForm)
 

--- a/test/controllers/EligibleControllerSpec.scala
+++ b/test/controllers/EligibleControllerSpec.scala
@@ -50,7 +50,7 @@ class EligibleControllerSpec extends ControllerBaseSpec
 
     "return a SEE OTHER (303)" in {
       status(goodRequest) must be(Status.SEE_OTHER)
-      redirectLocation(goodRequest).get mustBe controllers.routes.ContactEmailController.showContactEmail().url
+      redirectLocation(goodRequest).get mustBe controllers.preferences.routes.PreferencesController.checkPreferences().url
     }
   }
 

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import auth.authenticatedFakeRequest

--- a/test/controllers/NotEligibleControllerSpec.scala
+++ b/test/controllers/NotEligibleControllerSpec.scala
@@ -81,7 +81,7 @@ class NotEligibleControllerSpec extends ControllerBaseSpec
       val goodRequest = callShow(NotEligibleForm.option_signup)
 
       status(goodRequest) must be(Status.SEE_OTHER)
-      redirectLocation(goodRequest).get mustBe controllers.routes.ContactEmailController.showContactEmail().url
+      redirectLocation(goodRequest).get mustBe controllers.preferences.routes.PreferencesController.checkPreferences().url
 
       await(goodRequest)
       verifyKeystore(fetchNotEligible = 0, saveNotEligible = 1, fetchIncomeSource = 1)

--- a/test/controllers/TermsControllerSpec.scala
+++ b/test/controllers/TermsControllerSpec.scala
@@ -93,8 +93,8 @@ class TermsControllerSpec extends ControllerBaseSpec
   }
 
   "The back url" should {
-    s"point to ${controllers.routes.ContactEmailController.showContactEmail().url}" in {
-      TestTermsController.backUrl mustBe controllers.routes.ContactEmailController.showContactEmail().url
+    s"point to ${controllers.preferences.routes.PreferencesController.checkPreferences().url}" in {
+      TestTermsController.backUrl mustBe controllers.preferences.routes.PreferencesController.checkPreferences().url
     }
   }
 

--- a/test/controllers/TermsControllerSpec.scala
+++ b/test/controllers/TermsControllerSpec.scala
@@ -92,11 +92,5 @@ class TermsControllerSpec extends ControllerBaseSpec
     }
   }
 
-  "The back url" should {
-    s"point to ${controllers.preferences.routes.PreferencesController.checkPreferences().url}" in {
-      TestTermsController.backUrl mustBe controllers.preferences.routes.PreferencesController.checkPreferences().url
-    }
-  }
-
   authorisationTests
 }

--- a/test/controllers/business/BusinessIncomeTypeControllerSpec.scala
+++ b/test/controllers/business/BusinessIncomeTypeControllerSpec.scala
@@ -71,12 +71,12 @@ class BusinessIncomeTypeControllerSpec extends ControllerBaseSpec
         verifyKeystore(fetchIncomeType = 0, saveIncomeType = 1)
       }
 
-      s"redirect to '${controllers.routes.ContactEmailController.showContactEmail().url}'" in {
+      s"redirect to '${controllers.preferences.routes.PreferencesController.checkPreferences().url}'" in {
         setupMockKeystoreSaveFunctions()
 
         val goodRequest = callShow(isEditMode = false)
 
-        redirectLocation(goodRequest) mustBe Some(controllers.routes.ContactEmailController.showContactEmail().url)
+        redirectLocation(goodRequest) mustBe Some(controllers.preferences.routes.PreferencesController.checkPreferences().url)
 
         await(goodRequest)
         verifyKeystore(fetchIncomeType = 0, saveIncomeType = 1)

--- a/test/controllers/preferences/PreferencesControllerSpec.scala
+++ b/test/controllers/preferences/PreferencesControllerSpec.scala
@@ -48,10 +48,11 @@ class PreferencesControllerSpec extends ControllerBaseSpec
 
     def result = TestPreferencesController.checkPreferences(request)
 
-    "Return status (200) if paperless is activated" in {
+    "Redirect to Terms and Conditions if paperless is activiated" in {
       setupCheckPaperless(paperlessActivated)
 
-      status(result) must be(Status.OK)
+      status(result) must be(Status.SEE_OTHER)
+      redirectLocation(result).get must be(controllers.routes.TermsController.showTerms().url)
     }
 
     "Redirect to preferences service if paperless is deactivated" in {
@@ -76,10 +77,11 @@ class PreferencesControllerSpec extends ControllerBaseSpec
 
     def result = TestPreferencesController.callback(request)
 
-    "Return status (200) if paperless is activated" in {
+    "Redirect to Terms and Conditions if paperless is activiated" in {
       setupCheckPaperless(paperlessActivated)
 
-      status(result) must be(Status.OK)
+      status(result) must be(Status.SEE_OTHER)
+      redirectLocation(result).get must be(controllers.routes.TermsController.showTerms().url)
     }
 
     "Redirect to do you still want to continue page if paperless deactivated" in {

--- a/test/views/EligibleViewSpec.scala
+++ b/test/views/EligibleViewSpec.scala
@@ -25,7 +25,7 @@ import utils.UnitTestTrait
 
 class EligibleViewSpec extends UnitTestTrait {
 
-  lazy val backUrl = controllers.routes.ContactEmailController.showContactEmail().url
+  lazy val backUrl = controllers.preferences.routes.PreferencesController.checkPreferences().url
   lazy val page = views.html.eligible(
     postAction = controllers.routes.EligibleController.submitEligible(),
     backUrl = backUrl

--- a/test/views/SummaryPageViewSpec.scala
+++ b/test/views/SummaryPageViewSpec.scala
@@ -188,19 +188,20 @@ class SummaryPageViewSpec extends UnitTestTrait {
       )
     }
 
-    "display the correct info for the contact email" in {
-      val sectionId = ContactEmailId
-      val expectedQuestion = messages.contact_email
-      val expectedAnswer = testContactEmail.emailAddress
-      val expectedEditLink = controllers.routes.ContactEmailController.showContactEmail(editMode = true).url
-
-      sectionTest(
-        sectionId = sectionId,
-        expectedQuestion = expectedQuestion,
-        expectedAnswer = expectedAnswer,
-        expectedEditLink = expectedEditLink
-      )
-    }
+//    TODO - Change required following design around what will be displayed for digital preference decision
+//    "display the correct info for the contact email" in {
+//      val sectionId = ContactEmailId
+//      val expectedQuestion = messages.contact_email
+//      val expectedAnswer = testContactEmail.emailAddress
+//      val expectedEditLink = controllers.routes.ContactEmailController.showContactEmail(editMode = true).url
+//
+//      sectionTest(
+//        sectionId = sectionId,
+//        expectedQuestion = expectedQuestion,
+//        expectedAnswer = expectedAnswer,
+//        expectedEditLink = expectedEditLink
+//      )
+//    }
 
     "display the correct info for the terms" in {
       val sectionId = TermsId

--- a/test/views/TermsViewSpec.scala
+++ b/test/views/TermsViewSpec.scala
@@ -29,18 +29,11 @@ class TermsViewSpec extends UnitTestTrait {
   lazy val backUrl = controllers.preferences.routes.PreferencesController.checkPreferences().url
   lazy val page = views.html.terms(
     termsForm = TermForm.termForm,
-    postAction = controllers.routes.TermsController.submitTerms(),
-    backUrl = backUrl
+    postAction = controllers.routes.TermsController.submitTerms()
   )(FakeRequest(), applicationMessages, appConfig)
   lazy val document = Jsoup.parse(page.body)
 
   "The Terms view" should {
-
-    s"have a back buttong pointed to $backUrl" in {
-      val backLink = document.select("#back")
-      backLink.isEmpty mustBe false
-      backLink.attr("href") mustBe backUrl
-    }
 
     s"have the title '${messages.title}'" in {
       document.title() must be(messages.title)

--- a/test/views/TermsViewSpec.scala
+++ b/test/views/TermsViewSpec.scala
@@ -26,7 +26,7 @@ import utils.UnitTestTrait
 
 class TermsViewSpec extends UnitTestTrait {
 
-  lazy val backUrl = controllers.routes.ContactEmailController.showContactEmail().url
+  lazy val backUrl = controllers.preferences.routes.PreferencesController.checkPreferences().url
   lazy val page = views.html.terms(
     termsForm = TermForm.termForm,
     postAction = controllers.routes.TermsController.submitTerms(),


### PR DESCRIPTION
- Replaced the `contact-email` screen with the redirect to the Digital Preference service.
- The position of the preferences service in the flow may change, but it has been included for E2E testing in the original position of the flow.

- Note, a change was also made to the Terms and Conditions page to remove the 'Back Link' as this caused an endless loop back to terms and conditions. We are waiting on the final UX decision around the placement of the handoff for digital contact but for now, this back link has been removed.

**This has been tested with release 6.4.0 of PREFERENCES-FRONTEND - minor change to correct `paperless` to `optedIn` was required**