### PR TITLE
SAR-146: Updated the 'AlreadyEnrolled' tests and implementation

### DIFF
--- a/app/controllers/AlreadyEnrolledController.scala
+++ b/app/controllers/AlreadyEnrolledController.scala
@@ -18,20 +18,23 @@ package controllers
 
 import javax.inject.Inject
 
-import config.AppConfig
+import config.{AppConfig, BaseControllerConfig}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
+import services.KeystoreService
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.concurrent.Future
 
 
-class AlreadyEnrolledController @Inject()(implicit val applicationConfig: AppConfig,
-                                          val messagesApi: MessagesApi
-                                        ) extends FrontendController with I18nSupport {
+class AlreadyEnrolledController @Inject()(val baseConfig: BaseControllerConfig,
+                                         val messagesApi: MessagesApi
+                                        ) extends BaseController {
 
-  val enrolled = Action.async { implicit request =>
-    Future.successful(Ok(views.html.enrolled.already_enrolled()))
+  val enrolled = Authorised.async {  implicit user =>
+    implicit request =>
+      //TODO: The call needs to be replaced with the real sign-out postAction call
+      Future.successful(Ok(views.html.enrolled.already_enrolled(postAction = Call("POST","sign-out-url"))))
   }
 
 }

--- a/app/views/enrolled/already_enrolled.scala.html
+++ b/app/views/enrolled/already_enrolled.scala.html
@@ -1,10 +1,20 @@
 @import views.html.templates.main_template
 @import config.AppConfig
+@import helpers._
+@import uk.gov.hmrc.play.views.html.helpers.form
 
-@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(postAction: Call)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @main_template(title = Messages("already-enrolled.title"), bodyClasses = None) {
 
   <h1 class="heading-xlarge">@Messages("already-enrolled.heading")</h1>
+
+  <div class="form-group">
+    <p>@Messages("already-enrolled.para1")</p>
+  </div>
+
+  @form(action = postAction) {
+    @signOutButton()
+  }
 
 }

--- a/app/views/helpers/signOutButton.scala.html
+++ b/app/views/helpers/signOutButton.scala.html
@@ -1,0 +1,3 @@
+@(alternativeText: Option[String] = None)(implicit messages: Messages)
+
+<button class="button" type="submit" id="sign-out-button">@alternativeText.fold(Messages("base.sign-out"))(x => x)</button>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -108,7 +108,7 @@ microservice {
 }
 
 feature-switch {
-  enable-throttling = true
+  enable-throttling = false //Set to FALSE locally. In Base set to TRUE
 }
 
 metrics {

--- a/conf/messages
+++ b/conf/messages
@@ -110,8 +110,9 @@ throttle_limit.line_1                                           = To register fo
 
 
 ## Already enrolled page ##
-already-enrolled.title                                          = You already have a subscription
-already-enrolled.heading                                        = You already have a subscription
+already-enrolled.title                                          = You''ve already registered for digital tax updates
+already-enrolled.heading                                        = You''ve already registered for digital tax updates
+already-enrolled.para1                                          = Your Government Gateway ID is already registered for digital tax updates.
 
 ## Failure Messages ##
 notAuthorised.title                                             = Not Authorised

--- a/test/assets/MessageLookup.scala
+++ b/test/assets/MessageLookup.scala
@@ -168,8 +168,9 @@ object MessageLookup {
   }
 
   object AlreadyEnrolled {
-    val title = "You already have a subscription"
-    val heading = "You already have a subscription"
+    val title = "You've already registered for digital tax updates"
+    val heading = "You've already registered for digital tax updates"
+    val para1 = "Your Government Gateway ID is already registered for digital tax updates."
   }
 
   object Confirmation {

--- a/test/controllers/AlreadyEnrolledControllerSpec.scala
+++ b/test/controllers/AlreadyEnrolledControllerSpec.scala
@@ -19,21 +19,25 @@ package controllers
 import org.jsoup.Jsoup
 import play.api.http.Status
 import play.api.mvc.{Action, AnyContent}
-import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import auth._
+import assets.MessageLookup.{AlreadyEnrolled => messages}
 
 class AlreadyEnrolledControllerSpec extends ControllerBaseSpec {
 
   override val controllerName: String = "AlreadyEnrolledController"
-  override val authorisedRoutes: Map[String, Action[AnyContent]] = Map()
+  override val authorisedRoutes: Map[String, Action[AnyContent]] = Map(
+    "enrolled" -> TestAlreadyEnrolledController.enrolled()
+  )
 
-  object TestSessionTimeoutController extends SessionTimeoutController()(
-    MockBaseControllerConfig.applicationConfig,
-    messagesApi)
+  object TestAlreadyEnrolledController extends AlreadyEnrolledController(
+    MockBaseControllerConfig,
+    messagesApi
+  )
 
-  "Calling the enrolled action of the AlreadyEnrolledController" should {
+  "Calling the enrolled action of the AlreadyEnrolledController with an Authenticated User" should {
 
-    lazy val result = TestSessionTimeoutController.timeout(FakeRequest())
+    lazy val result = TestAlreadyEnrolledController.enrolled(authenticatedFakeRequest())
     lazy val document = Jsoup.parse(contentAsString(result))
 
     "return 200" in {
@@ -45,5 +49,16 @@ class AlreadyEnrolledControllerSpec extends ControllerBaseSpec {
       charset(result) must be(Some("utf-8"))
     }
 
+    s"render the already enrolled page" in {
+      document.title mustBe messages.heading
+    }
+
+    //TODO: Update with the sign-out postAction test
+    "the post action of the page rendered should be 'TODO - sign out URL'" ignore {
+      document.select("form").attr("action") mustBe "TODO - sign out URL"
+    }
+
   }
+
+  authorisationTests()
 }

--- a/test/views/AlreadyEnrolledViewSpec.scala
+++ b/test/views/AlreadyEnrolledViewSpec.scala
@@ -19,22 +19,40 @@ package views
 import assets.MessageLookup
 import org.jsoup.Jsoup
 import play.api.i18n.Messages.Implicits._
+import play.api.mvc.Call
 import play.api.test.FakeRequest
 import utils.UnitTestTrait
 
 class AlreadyEnrolledViewSpec extends UnitTestTrait {
 
-  lazy val page = views.html.enrolled.already_enrolled()(FakeRequest(), applicationMessages, appConfig)
+  lazy val testPostRoute = "testPostUrl"
+  lazy val page = views.html.enrolled.already_enrolled(Call("POST",testPostRoute))(FakeRequest(), applicationMessages, appConfig)
   lazy val document = Jsoup.parse(page.body)
 
   "The Already Enrolled view" should {
 
     s"have the title '${MessageLookup.AlreadyEnrolled.title}'" in {
-      document.title() must be (MessageLookup.AlreadyEnrolled.title)
+      document.title() must be(MessageLookup.AlreadyEnrolled.title)
     }
 
     s"have the heading (H1) '${MessageLookup.AlreadyEnrolled.heading}'" in {
-      document.getElementsByTag("H1").text() must be (MessageLookup.AlreadyEnrolled.heading)
+      document.getElementsByTag("H1").text() must be(MessageLookup.AlreadyEnrolled.heading)
+    }
+
+    s"have the paragraph (p) '${MessageLookup.AlreadyEnrolled.para1}'" in {
+      document.getElementsByTag("p").text() must include(MessageLookup.AlreadyEnrolled.para1)
+    }
+
+    "has a form" which {
+
+      "has a 'Sign Out' button" in {
+        document.select("#sign-out-button").isEmpty mustBe false
+      }
+
+      s"has a post action to '$testPostRoute'" in {
+        document.select("form").attr("action") mustBe testPostRoute
+        document.select("form").attr("method") mustBe "POST"
+      }
     }
   }
 }


### PR DESCRIPTION
Implemented the updated view for already enrolled.

For the sign-out functionality I've created a postAction that can be updated to call a `/sign-out` route on our frontend once it has been implemented. That route can re-direct to the CoAFE frontend signout route.

For now, it is TODO and the test is templated but ignored.