### PR TITLE
SAR-446: Added Sign Out button to main-income-error

### DIFF
--- a/app/controllers/MainIncomeErrorController.scala
+++ b/app/controllers/MainIncomeErrorController.scala
@@ -20,6 +20,7 @@ import javax.inject.Inject
 
 import config.BaseControllerConfig
 import play.api.i18n.MessagesApi
+import play.api.mvc.Call
 
 import scala.concurrent.Future
 
@@ -30,8 +31,9 @@ class MainIncomeErrorController @Inject()(val baseConfig: BaseControllerConfig,
 
   val mainIncomeError = Authorised.async { implicit user =>
     implicit request =>
-      Future.successful(Ok(views.html.main_income_error(backUrl)))
+      Future.successful(Ok(views.html.main_income_error(backUrl, getAction)))
   }
 
   lazy val backUrl: String = controllers.routes.IncomeSourceController.showIncomeSource().url
+  lazy val getAction: Call = controllers.routes.SignOutController.signOut()
 }

--- a/app/views/main_income_error.scala.html
+++ b/app/views/main_income_error.scala.html
@@ -1,8 +1,9 @@
+@import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.templates.main_template
 @import views.html.helpers._
 @import config.AppConfig
 
-@(backUrl: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(backUrl: String, getAction: Call)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @main_template(title = Messages("main-income-error.title"), bodyClasses = None) {
     @back_link(backUrl)
@@ -17,4 +18,8 @@
         </ul>
         <p>@Messages("main-income-error.para2")</p>
     </div>
+
+    @form(action = getAction) {
+        @signOutButton()
+    }
 }

--- a/app/views/no_nino.scala.html
+++ b/app/views/no_nino.scala.html
@@ -9,8 +9,6 @@
     <h1 class="heading-xlarge">@Messages("not-eligible.heading")</h1>
 
     @form(action = postAction) {
-
-        @continueButton(Messages("base.sign-out"))
-
+        @signOutButton()
     }
 }

--- a/app/views/throttling/daily_limit_reached.scala.html
+++ b/app/views/throttling/daily_limit_reached.scala.html
@@ -11,8 +11,6 @@
     <p>@Messages("throttle_limit.line_1")</p>
 
     @form(action = postAction) {
-
-        @continueButton(Messages("base.sign-out"))
-
+        @signOutButton()
     }
 }

--- a/test/views/MainIncomeErrorViewSpec.scala
+++ b/test/views/MainIncomeErrorViewSpec.scala
@@ -19,13 +19,15 @@ package views
 import assets.MessageLookup
 import org.jsoup.Jsoup
 import play.api.i18n.Messages.Implicits._
+import play.api.mvc.Call
 import play.api.test.FakeRequest
 import utils.UnitTestTrait
 
 class MainIncomeErrorViewSpec extends UnitTestTrait {
 
   lazy val backUrl: String = controllers.routes.IncomeSourceController.showIncomeSource().url
-  lazy val page = views.html.main_income_error(backUrl = backUrl)(FakeRequest(), applicationMessages, appConfig)
+  lazy val getAction: Call = controllers.routes.SignOutController.signOut()
+  lazy val page = views.html.main_income_error(backUrl, getAction)(FakeRequest(), applicationMessages, appConfig)
   lazy val document = Jsoup.parse(page.body)
 
   "The Main Income Error view" should {
@@ -56,6 +58,18 @@ class MainIncomeErrorViewSpec extends UnitTestTrait {
 
     s"have the paragraph (LI) '${MessageLookup.MainIncomeError.bullet3}'" in {
       document.getElementsByTag("LI").text() must include (MessageLookup.MainIncomeError.bullet3)
+    }
+
+    "has a form" which {
+
+      "has a 'Sign Out' button" in {
+        document.select("#sign-out-button").isEmpty mustBe false
+      }
+
+      s"has a GET action to '${getAction.url}'" in {
+        document.select("form").attr("action") mustBe getAction.url
+        document.select("form").attr("method") mustBe "GET"
+      }
     }
   }
 }


### PR DESCRIPTION
- Also refactored other views to use the `signOutButton()` helper rather than a continue button with an override message. Just to be cleaner.