### PR TITLE
Update reset profile call to use government-gateway-authentication/re…

### DIFF
--- a/app/agent/testonly/connectors/GGAuthenticationConnector.scala
+++ b/app/agent/testonly/connectors/GGAuthenticationConnector.scala
@@ -28,10 +28,10 @@ import uk.gov.hmrc.play.bootstrap.http.HttpClient
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class AuthenticatorConnector @Inject()(appConfig: TestOnlyAppConfig,
-                                       http: HttpClient)(implicit ec: ExecutionContext) extends RawResponseReads {
+class GGAuthenticationConnector @Inject()(appConfig: TestOnlyAppConfig,
+                                          http: HttpClient)(implicit ec: ExecutionContext) extends RawResponseReads {
 
-  lazy val refreshURI = s"${appConfig.authenticatorUrl}/authenticator/refresh-profile"
+  lazy val refreshURI = s"${appConfig.ggAuthenticationURL}/government-gateway-authentication/refresh-profile"
 
   def refreshProfile()(implicit hc: HeaderCarrier): Future[HttpResponse] =
     http.POSTEmpty[HttpResponse](refreshURI)

--- a/app/agent/testonly/controllers/DeEnrolController.scala
+++ b/app/agent/testonly/controllers/DeEnrolController.scala
@@ -20,18 +20,18 @@ package agent.testonly.controllers
 
 import javax.inject.{Inject, Singleton}
 
-import agent.testonly.connectors.{AuthenticatorConnector, DeEnrolmentConnector}
+import agent.testonly.connectors.{GGAuthenticationConnector, DeEnrolmentConnector}
 import play.api.mvc.Action
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 @Singleton
 class DeEnrolController @Inject()(deEnrolmentConnector: DeEnrolmentConnector,
-                                  authenticatorConnector: AuthenticatorConnector) extends FrontendController {
+                                  ggAuthenticationConnector: GGAuthenticationConnector) extends FrontendController {
 
   val resetUsers = Action.async { implicit request =>
     for {
       ggStubResponse <- deEnrolmentConnector.resetUsers()
-      authRefreshed <- authenticatorConnector.refreshProfile()
+      authRefreshed <- ggAuthenticationConnector.refreshProfile()
     } yield (authRefreshed.status, ggStubResponse.status) match {
       case (NO_CONTENT, OK) => Ok("Successfully Reset GG stubbed user")
       case _ => BadRequest(s"Failed to Reset GG stubbed user: ggStubResponse=${ggStubResponse.status}, authRefreshed=${authRefreshed.status}")


### PR DESCRIPTION
…fresh-profile rather that the deprecated authenticator/refresh-profile.

This is safe because authenticator/refresh-profile has been a simple proxy of GGA for sometime.