### PR TITLE
SAR-2412: Redirect to home from rent uk property bug

### DIFF
--- a/app/core/auth/AuthPredicates.scala
+++ b/app/core/auth/AuthPredicates.scala
@@ -133,11 +133,9 @@ object AuthPredicates extends Results {
   lazy val userMatching: Result = Redirect(usermatching.controllers.routes.UserDetailsController.show())
 
   val ninoPredicate: AuthPredicate[IncomeTaxSAUser] = implicit request => user =>
-    if (user.nino.isDefined) {
-      Right(AuthPredicateSuccess)
-    } else {
-      Left(Future.successful(userMatching withJourneyState UserMatching))
-    }
+    if (user.nino.isDefined) Right(AuthPredicateSuccess)
+    else if (user.utr.isDefined) Left(Future.successful(homeRoute))
+    else Left(Future.successful(userMatching withJourneyState UserMatching))
 
   lazy val alreadyEnrolledRoute: Result = Redirect(incometax.subscription.controllers.routes.AlreadyEnrolledController.show())
 


### PR DESCRIPTION
This fixes the issue when we directly access the rent uk property
page, without a nino but with a utr, which should be redirecting
to home instead of user matching.