### PR TITLE
Bug fix: Convert timestamp to seconds before create LocalDateTime

### DIFF
--- a/app/models/common/TimestampModel.scala
+++ b/app/models/common/TimestampModel.scala
@@ -16,7 +16,6 @@
 
 package models.common
 
-import org.joda.time.DateTimeZone
 import play.api.libs.json._
 
 import java.time.{LocalDateTime, ZoneOffset}
@@ -26,7 +25,7 @@ case class TimestampModel(dateTime: LocalDateTime)
 object TimestampModel {
   private val reads: Reads[TimestampModel] =
     (JsPath \ "$date").read[Long]
-      .map[TimestampModel](dateTimeSeconds => TimestampModel(LocalDateTime.ofEpochSecond(dateTimeSeconds, 0, ZoneOffset.UTC)))
+      .map[TimestampModel](dateTimeSeconds => TimestampModel(LocalDateTime.ofEpochSecond(dateTimeSeconds/1000, 0, ZoneOffset.UTC)))
 
   private val writes: Writes[TimestampModel] = new Writes[TimestampModel] {
     def writes(model: TimestampModel): JsValue = JsString(model.dateTime.toString())

--- a/test/models/common/TimestampModelSpec.scala
+++ b/test/models/common/TimestampModelSpec.scala
@@ -16,17 +16,18 @@
 
 package models.common
 
-import java.time.LocalDateTime
 import org.scalatest.MustMatchers.convertToAnyMustWrapper
-import play.api.libs.json.{JsResult, Json}
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+import play.api.libs.json.{JsResult, Json}
+
+import java.time.LocalDateTime
 
 class TimestampModelSpec extends WordSpecLike with Matchers with OptionValues {
   "TimestampModel" should {
     "deserialize the MongoDB response" in {
-      val actual: JsResult[TimestampModel] = Json.fromJson[TimestampModel](Json.parse("""{"$date":0}"""))
+      val actual: JsResult[TimestampModel] = Json.fromJson[TimestampModel](Json.parse("""{"$date":1642075200000}"""))
       val expected = TimestampModel(
-        LocalDateTime.of(1970, 1, 1, 0, 0, 0, 0)
+        LocalDateTime.of(2022, 1, 13, 12, 0, 0, 0)
       )
 
       actual.get mustBe expected


### PR DESCRIPTION
Convert timestamp to seconds before create LocalDateTime

Signed-off-by: Samir Benzenine <samir.benzenine@digital.hmrc.gov.uk>