### PR TITLE
ITSASU-5016

### DIFF
--- a/app/views/errors/ServiceError.scala.html
+++ b/app/views/errors/ServiceError.scala.html
@@ -1,0 +1,64 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import views.html.helpers.SaveAndContinueButtonHelper
+@import views.html.templates.{PrincipalMainTemplate, AgentMainTemplate}
+
+@this(
+    individualMainTemplate: PrincipalMainTemplate,
+    agentMainTemplate: AgentMainTemplate,
+    form: FormWithCSRF,
+    saveAndContinueButtonHelper: SaveAndContinueButtonHelper
+)
+
+@(postAction: Call, isAgent: Boolean)(implicit request: Request[_], messages: Messages)
+
+@mainTemplate(title: String)(block: Html) = @{
+    if(isAgent) {
+        agentMainTemplate(title = title, showSignOutLink = true)(block)
+    } else {
+        individualMainTemplate(title = title, showSignOutLink = true)(block)
+    }
+}
+
+@mainTemplate(title = messages("service-error.title")) {
+
+    <h1 class="govuk-heading-l">@messages("service-error.title")</h1>
+
+    @if(isAgent) {
+        <p class="govuk-body">@messages("service-error.agent.paragraph")</p>
+        <div class="form-group">
+            @form(action = postAction) {
+                @saveAndContinueButtonHelper(
+                    isIndividual = false,
+                    saveAndContinueText = Some(messages("base.try-again")),
+                    saveAndReturnReference = None
+                )
+            }
+        </div>
+    } else {
+        <p class="govuk-body">@messages("service-error.individual.paragraph")</p>
+        <div class="form-group">
+            @form(action = postAction) {
+                @saveAndContinueButtonHelper(
+                    isIndividual = true,
+                    saveAndContinueText = Some(messages("base.try-again")),
+                    saveAndReturnReference = None
+                )
+            }
+        </div>
+    }
+}

--- a/app/views/errors/ServiceError.scala.html
+++ b/app/views/errors/ServiceError.scala.html
@@ -14,14 +14,14 @@
  * limitations under the License.
  *@
 
-@import views.html.helpers.SaveAndContinueButtonHelper
+@import views.html.helpers.ButtonHelper
 @import views.html.templates.{PrincipalMainTemplate, AgentMainTemplate}
 
 @this(
     individualMainTemplate: PrincipalMainTemplate,
     agentMainTemplate: AgentMainTemplate,
     form: FormWithCSRF,
-    saveAndContinueButtonHelper: SaveAndContinueButtonHelper
+    buttonHelper: ButtonHelper
 )
 
 @(postAction: Call, isAgent: Boolean)(implicit request: Request[_], messages: Messages)
@@ -40,25 +40,17 @@
 
     @if(isAgent) {
         <p class="govuk-body">@messages("service-error.agent.paragraph")</p>
-        <div class="form-group">
-            @form(action = postAction) {
-                @saveAndContinueButtonHelper(
-                    isIndividual = false,
-                    saveAndContinueText = Some(messages("base.try-again")),
-                    saveAndReturnReference = None
-                )
-            }
-        </div>
+
     } else {
         <p class="govuk-body">@messages("service-error.individual.paragraph")</p>
-        <div class="form-group">
-            @form(action = postAction) {
-                @saveAndContinueButtonHelper(
-                    isIndividual = true,
-                    saveAndContinueText = Some(messages("base.try-again")),
-                    saveAndReturnReference = None
-                )
-            }
-        </div>
     }
+
+    <div class="form-group">
+        @form(action = postAction) {
+            @buttonHelper(
+            buttonText = messages("base.try-again"),
+            href = None
+            )
+        }
+    </div>
 }

--- a/app/views/errors/ServiceError.scala.html
+++ b/app/views/errors/ServiceError.scala.html
@@ -48,8 +48,7 @@
     <div class="form-group">
         @form(action = postAction) {
             @buttonHelper(
-            buttonText = messages("base.try-again"),
-            href = None
+            buttonText = messages("base.try-again")
             )
         }
     </div>

--- a/conf/messages
+++ b/conf/messages
@@ -1338,3 +1338,7 @@ error.contact-hmrc.b2                                                   = Fill i
 error.contact-hmrc.b3                                                   = In the box labelled “What do you need help with?”, type “Tell me when I can sign up”.
 error.contact-hmrc.p3                                                   = We’ll contact you with any updates and let you know when you can sign up.
 error.contact-hmrc.contact-us                                           = Contact us form
+
+service-error.title                                                     = Sorry, there is a problem with the service
+service-error.agent.paragraph                                           = We could not confirm your client’s details. Please try again.
+service-error.individual.paragraph                                      = We could not confirm your details. Please try again.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -1335,3 +1335,7 @@ error.contact-hmrc.b2                                                   = Nodwch
 error.contact-hmrc.b3                                                   = Yn y blwch “Gyda beth ydych angen help?”, nodwch “Rhowch wybod i mi pryd y gallaf gofrestru / Tell me when I can sign up”.
 error.contact-hmrc.p3                                                   = Byddwn yn cysylltu â chi i rannu unrhyw ddiweddariadau ac i roi gwybod i chi pryd y gallwch gofrestru.
 error.contact-hmrc.contact-us                                           = Ffurflen gyswllt
+
+service-error.title                                                     = Mae’n ddrwg gennym, ond mae problem gyda’r gwasanaeth
+service-error.agent.paragraph                                           = Nid oedd modd i ni gadarnhau’ch manylion. Rhowch gynnig arall arni.
+service-error.individual.paragraph                                      = Nid oedd modd i ni gadarnhau manylion eich cleient. Rhowch gynnig arall arni.

--- a/test/views/errors/ServiceErrorViewSpec.scala
+++ b/test/views/errors/ServiceErrorViewSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.errors
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import play.twirl.api.HtmlFormat
+import utilities.ViewSpec
+import views.html.errors.ServiceError
+
+class ServiceErrorViewSpec extends ViewSpec {
+
+  def serviceError: ServiceError = app.injector.instanceOf[ServiceError]
+
+  def page(isAgent: Boolean): HtmlFormat.Appendable =
+    serviceError(
+      testCall,
+      isAgent
+    )
+
+  def document(isAgent: Boolean): Document = Jsoup.parse(page(isAgent).body)
+
+  object ServiceErrorMessages {
+    val title = "Sorry, there is a problem with the service"
+    val heading = "Sorry, there is a problem with the service"
+    val paragraphAgent = "We could not confirm your client’s details. Please try again."
+    val paragraphIndividual = "We could not confirm your details. Please try again."
+    val TryAgain = "Try again"
+  }
+
+  "ContactHMRC" must {
+    "has correct template for individuals" in new TemplateViewTest(
+      view = page(false),
+      isAgent = false,
+      title = ServiceErrorMessages.title
+    )
+
+    "has correct template for agents" in new TemplateViewTest(
+      view = page(true),
+      isAgent = true,
+      title = ServiceErrorMessages.title
+    )
+
+    "has a page heading" in {
+      Seq(false, true).foreach { isAgent =>
+        document(isAgent).mainContent.selectHead("h1").text mustBe ServiceErrorMessages.heading
+      }
+    }
+
+    "has a first paragraph for agent" in {
+      document(true).mainContent.selectNth("p", 1).text mustBe ServiceErrorMessages.paragraphAgent
+    }
+
+    "has a first paragraph for individual" in {
+      document(false).mainContent.selectNth("p", 1).text mustBe ServiceErrorMessages.paragraphIndividual
+    }
+
+    "has a form" which {
+      def form(isAgent: Boolean): Element =
+        document(isAgent).selectHead("form")
+
+      "has the correct attributes" in {
+        Seq(false, true).foreach { isAgent =>
+          form(isAgent).attr("method") mustBe testCall.method
+          form(isAgent).attr("action") mustBe testCall.url
+        }
+      }
+
+      "has an try again burron" in {
+        Seq(false, true).foreach { isAgent =>
+          form(isAgent).selectHead("button").text mustBe ServiceErrorMessages.TryAgain
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Some Dev Notes from the Docs when reviewing:
  
  1. Button to link have the same function as the ‘Confirm and send’ button from the CYA page - linking to the loading wheel. 
  
  2. Only show this page when the user can try again, show the standard tech issue with the service page for all other scenarios.
  
  3. Note: Wording of “...your details” “...your client’s details” is conditional depending on individual or agent users.
