### PR TITLE
Update repository.yaml with new test repo

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,4 +1,4 @@
 repoVisibility: public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71
 test-repositories:
   - income-tax-subscription-performance-tests
-  - income-tax-subscription-acceptance-tests
+  - income-tax-subscription-journey-tests


### PR DESCRIPTION
The UI journey tests now exist under a different repository name. Updating this will then help the catalogue present the correct test suite for the service.